### PR TITLE
Add local symbol table management

### DIFF
--- a/src/ALexico/AnLexico.java
+++ b/src/ALexico/AnLexico.java
@@ -6,6 +6,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.LinkedHashMap;
 
 public class AnLexico {
 	private Map<String, String> palReservadas;
@@ -22,7 +23,7 @@ public class AnLexico {
 		this.posicionCaracter = 0;
 		this.linea = 1;
 		this.contadorIds = 1;
-		tablaSimbolos = new HashMap<>();
+                tablaSimbolos = new LinkedHashMap<>();
 		guardarPalReservadas();
 		guardarOperadores();
 
@@ -191,36 +192,39 @@ public class AnLexico {
 		}
 	}
 
-	private void inicializarTablaSimbolos() throws IOException {
-		escritorTablaSimbolos.write("TABLA PRINCIPAL #1:\n");
-	}
+        private void inicializarTablaSimbolos() throws IOException {
+                escritorTablaSimbolos.write("Tabla Global:\n");
+                escritorTablaSimbolos.write("TABLA DE SIMBOLOS PRINCIPAL #1:\n");
+        }
 
-	private void actualizarTablaSimbolos() throws IOException {
-		escritorTablaSimbolos = new BufferedWriter(new FileWriter("src/ALexico/TablaSimbolos.txt"));
-		escritorTablaSimbolos.write("TABLA PRINCIPAL #1:\n");
+        private void actualizarTablaSimbolos() throws IOException {
+                escritorTablaSimbolos = new BufferedWriter(new FileWriter("src/ALexico/TablaSimbolos.txt"));
+                escritorTablaSimbolos.write("Tabla Global:\n");
+                escritorTablaSimbolos.write("TABLA DE SIMBOLOS PRINCIPAL #1:\n");
 
-		for (Map.Entry<String, Map<String, Object>> entrada : tablaSimbolos.entrySet()) {
-			String lexema = entrada.getKey();
-			Map<String, Object> atributos = entrada.getValue();
+                for (Map.Entry<String, Map<String, Object>> entrada : tablaSimbolos.entrySet()) {
+                        String lexema = entrada.getKey();
+                        Map<String, Object> atributos = entrada.getValue();
 
-			// ✅ Escribir lexema según formato del PDF
-			escritorTablaSimbolos.write("* LEXEMA : '" + lexema + "'\n");
+                        // Formato según README
+                        escritorTablaSimbolos.write("* LEXEMA: '" + lexema + "'\n");
+                        escritorTablaSimbolos.write("Atributos:\n");
 
-			// ✅ Escribir TODOS los atributos (léxicos + semánticos)
-			for (Map.Entry<String, Object> atributo : atributos.entrySet()) {
-				String nombreAtributo = atributo.getKey();
-				Object valorAtributo = atributo.getValue();
+                        for (Map.Entry<String, Object> atributo : atributos.entrySet()) {
+                                String nombreAtributo = atributo.getKey();
+                                Object valorAtributo = atributo.getValue();
 
-				if (valorAtributo instanceof String) {
-					escritorTablaSimbolos.write("  + " + nombreAtributo + " : '" + valorAtributo + "'\n");
-				} else {
-					escritorTablaSimbolos.write("  + " + nombreAtributo + " : " + valorAtributo + "\n");
-				}
-			}
-		}
+                                if (valorAtributo instanceof String) {
+                                        escritorTablaSimbolos.write("+ " + nombreAtributo + ": '" + valorAtributo + "'\n");
+                                } else {
+                                        escritorTablaSimbolos.write("+ " + nombreAtributo + ": " + valorAtributo + "\n");
+                                }
+                        }
+                        escritorTablaSimbolos.write("-------------------------------------\n");
+                }
 
-		escritorTablaSimbolos.flush();
-	}
+                escritorTablaSimbolos.flush();
+        }
 
 	/**
 	 * Genera la tabla de símbolos completa con información léxica + semántica
@@ -234,29 +238,30 @@ public class AnLexico {
 			}
 
 			// Crear nuevo escritor para regenerar el archivo completo
-			escritorTablaSimbolos = new BufferedWriter(new FileWriter("src/ALexico/TablaSimbolos.txt"));
-			escritorTablaSimbolos.write("TABLA PRINCIPAL #1:\n");
+                        escritorTablaSimbolos = new BufferedWriter(new FileWriter("src/ALexico/TablaSimbolos.txt"));
+                        escritorTablaSimbolos.write("Tabla Global:\n");
+                        escritorTablaSimbolos.write("TABLA DE SIMBOLOS PRINCIPAL #1:\n");
 
-			// Escribir todas las entradas con información completa
-			for (Map.Entry<String, Map<String, Object>> entrada : tablaSimbolos.entrySet()) {
-				String lexema = entrada.getKey();
-				Map<String, Object> atributos = entrada.getValue();
+                        // Escribir todas las entradas con información completa
+                        for (Map.Entry<String, Map<String, Object>> entrada : tablaSimbolos.entrySet()) {
+                                String lexema = entrada.getKey();
+                                Map<String, Object> atributos = entrada.getValue();
 
-				// Escribir lexema según formato del PDF
-				escritorTablaSimbolos.write("* LEXEMA : '" + lexema + "'\n");
+                                escritorTablaSimbolos.write("* LEXEMA: '" + lexema + "'\n");
+                                escritorTablaSimbolos.write("Atributos:\n");
 
-				// Escribir TODOS los atributos (léxicos + semánticos)
-				for (Map.Entry<String, Object> atributo : atributos.entrySet()) {
-					String nombreAtributo = atributo.getKey();
-					Object valorAtributo = atributo.getValue();
+                                for (Map.Entry<String, Object> atributo : atributos.entrySet()) {
+                                        String nombreAtributo = atributo.getKey();
+                                        Object valorAtributo = atributo.getValue();
 
-					if (valorAtributo instanceof String) {
-						escritorTablaSimbolos.write("  + " + nombreAtributo + " : '" + valorAtributo + "'\n");
-					} else {
-						escritorTablaSimbolos.write("  + " + nombreAtributo + " : " + valorAtributo + "\n");
-					}
-				}
-			}
+                                        if (valorAtributo instanceof String) {
+                                                escritorTablaSimbolos.write("+ " + nombreAtributo + ": '" + valorAtributo + "'\n");
+                                        } else {
+                                                escritorTablaSimbolos.write("+ " + nombreAtributo + ": " + valorAtributo + "\n");
+                                        }
+                                }
+                                escritorTablaSimbolos.write("-------------------------------------\n");
+                        }
 
 			escritorTablaSimbolos.close();
 

--- a/src/AnSintDesRec/AnSintactico.java
+++ b/src/AnSintDesRec/AnSintactico.java
@@ -67,10 +67,10 @@ public class AnSintactico {
 	/**
 	 * Genera la tabla de símbolos unificada al final del análisis
 	 */
-	public void generarTablaUnificada() {
-		// Solicitar al léxico que regenere el archivo con información completa
-		lexico.generarTablaCompleta();
-	}
+        public void generarTablaUnificada() {
+                // Solicitar al semántico que genere la tabla completa (global + locales)
+                semantico.generarTablaCompleta();
+        }
 
 
 
@@ -320,18 +320,20 @@ public class AnSintactico {
 		switch(tokenActual.getCodigo()) {
 			case "function":
 				parse += " 24";
-				equipara("function");
-				String tipoRetorno = H(); // ✅ H devuelve tipo de retorno
-				String lexemaFuncion = obtenerLexemaId(); // ✅ Obtener lexema de la función
-				equipara("id");
-				equipara("par1");
-				int numParametros = A(); // ✅ A debe devolver número de parámetros
-				semantico.validarDeclaracionFuncion(lexemaFuncion, tipoRetorno, numParametros); // ✅ Validación semántica
-				equipara("par2");
-				equipara("cor1");
-				C();
-				equipara("cor2");
-				break;
+                                equipara("function");
+                                String tipoRetorno = H(); // ✅ H devuelve tipo de retorno
+                                String lexemaFuncion = obtenerLexemaId(); // ✅ Obtener lexema de la función
+                                equipara("id");
+                                semantico.iniciarFuncion(lexemaFuncion); // Tabla local
+                                equipara("par1");
+                                int numParametros = A(); // ✅ A devuelve número de parámetros
+                                semantico.validarDeclaracionFuncion(lexemaFuncion, tipoRetorno, numParametros); // ✅ Validación semántica
+                                equipara("par2");
+                                equipara("cor1");
+                                C();
+                                equipara("cor2");
+                                semantico.cerrarFuncion();
+                                break;
 			default:
 				error("Token inesperado en F. Se encontro el token " + tokenActual.getCodigo() + " en la linea " + lexico.getLinea());
 				break;


### PR DESCRIPTION
## Summary
- support local symbol table tracking in `AnSemantico`
- open and close function scopes in parser
- delegate final symbol table generation to `AnSemantico`

## Testing
- `javac @sources.txt` *(warns: module name should avoid digits)*
- `java -cp src main.Main` *(fails: Error token id con atributo inválido)*

------
https://chatgpt.com/codex/tasks/task_e_684f0701ed988323acbd6f48b2cd4401