### PR TITLE
Restrict global assignments

### DIFF
--- a/src/ALexico/AnLexico.java
+++ b/src/ALexico/AnLexico.java
@@ -59,6 +59,16 @@ public class AnLexico {
                 return tablaSimbolos;
         }
 
+        // Indica si actualmente el análisis está dentro de una función
+        public boolean dentroDeFuncion() {
+                return funcionActual != null;
+        }
+
+        // Verifica si un identificador pertenece a la tabla global
+        public boolean esVariableGlobal(String lexema) {
+                return tablaGlobal.containsKey(lexema);
+        }
+
 	private void guardarPalReservadas() {
 		palReservadas = new HashMap<>();
 		palReservadas.put("boolean", "boolean");

--- a/src/AnSintDesRec/AnSemantico.java
+++ b/src/AnSintDesRec/AnSemantico.java
@@ -118,6 +118,13 @@ public class AnSemantico {
      * Valida una asignación (reglas S' → = E ; y S' → |= E ;)
      */
     public void validarAsignacion(String lexema, String tipoExpresion, String operador) {
+        // No permitir asignaciones a variables globales fuera de una función
+        if (!lexico.dentroDeFuncion() && lexico.esVariableGlobal(lexema)) {
+            throw new RuntimeException(
+                    "Error semántico: No se puede asignar a la variable global '" + lexema +
+                    "' fuera de una función en la línea " + lexico.getLinea());
+        }
+
         String tipoVariable = buscaTipoTS(lexema);
 
         if (operador.equals("|=")) {


### PR DESCRIPTION
## Summary
- expose helpers in the lexer to query scope information
- prevent assignments to global variables when not inside a function

## Testing
- `javac @sources.txt`

------
https://chatgpt.com/codex/tasks/task_e_6850102a4e3083238fd2bc168e444c48