### PR TITLE
Restrict global assignments

### DIFF
--- a/src/ALexico/AnLexico.java
+++ b/src/ALexico/AnLexico.java
@@ -59,6 +59,16 @@ public class AnLexico {
                 return tablaSimbolos;
         }
 
+        // Indica si actualmente el análisis está dentro de una función
+        public boolean dentroDeFuncion() {
+                return funcionActual != null;
+        }
+
+        // Verifica si un identificador pertenece a la tabla global
+        public boolean esVariableGlobal(String lexema) {
+                return tablaGlobal.containsKey(lexema);
+        }
+
 	private void guardarPalReservadas() {
 		palReservadas = new HashMap<>();
 		palReservadas.put("boolean", "boolean");

--- a/src/AnSintDesRec/AnSemantico.java
+++ b/src/AnSintDesRec/AnSemantico.java
@@ -118,6 +118,13 @@ public class AnSemantico {
      * Valida una asignación (reglas S' → = E ; y S' → |= E ;)
      */
     public void validarAsignacion(String lexema, String tipoExpresion, String operador) {
+        // No permitir asignaciones a variables globales fuera de una función
+        if (!lexico.dentroDeFuncion() && lexico.esVariableGlobal(lexema)) {
+            throw new RuntimeException(
+                    "Error semántico: No se puede asignar a la variable global '" + lexema +
+                    "' fuera de una función en la línea " + lexico.getLinea());
+        }
+
         String tipoVariable = buscaTipoTS(lexema);
 
         if (operador.equals("|=")) {
@@ -218,6 +225,23 @@ public class AnSemantico {
         Map<String, Object> atributos = tablaSimbolos.get(lexema);
         atributos.put("TipoParam" + String.format("%02d", numeroParam), tipoParam);
         tablaSimbolos.put(lexema, atributos);
+    }
+
+    /**
+     * Obtiene el tipo de retorno de una función
+     */
+    public String obtenerTipoRetorno(String lexema) {
+        if (!tablaSimbolos.containsKey(lexema)) {
+            throw new RuntimeException("Error semántico: Identificador '" + lexema +
+                    "' no declarado en la línea " + lexico.getLinea());
+        }
+
+        Map<String, Object> atributos = tablaSimbolos.get(lexema);
+        String tipo = (String) atributos.get("tipo");
+        if (!"funcion".equals(tipo)) {
+            return null;
+        }
+        return (String) atributos.get("TipoRetorno");
     }
 
     // ==================== FUNCIONES AUXILIARES ====================

--- a/src/AnSintDesRec/AnSintactico.java
+++ b/src/AnSintDesRec/AnSintactico.java
@@ -506,11 +506,10 @@ public class AnSintactico {
 		switch(tokenActual.getCodigo()) {
 			case "id":
 				parse += " 41";
-				String lexemaVar = obtenerLexemaId(); // ✅ Obtener lexema
-				String tipoVar = semantico.buscaTipoTS(lexemaVar); // ✅ Buscar tipo en TS
-				equipara("id");
-				V_prime();
-				return tipoVar; // ✅ Devolver tipo de la variable
+                                String lexemaVar = obtenerLexemaId(); // ✅ Obtener lexema
+                                String tipoVar = semantico.buscaTipoTS(lexemaVar); // ✅ Buscar tipo en TS
+                                equipara("id");
+                                return V_prime(lexemaVar, tipoVar); // ✅ Puede cambiar si es llamada a función
 			case "par1":
 				parse += " 42";
 				equipara("par1");
@@ -533,27 +532,32 @@ public class AnSintactico {
 
 	
 	//Funcion V'
-	public void V_prime() {
-		switch(tokenActual.getCodigo()) {
-			case "par1":
-				parse += " 45";//parse.add(45); //Regla V' --> (L)
-				equipara("par1");
-				L();
-				equipara("par2");
-				break;
-			case "mayor":
-			case "suma":
-			case "punCom":
-			case "coma":
-			case "par2":
-			case "asigOL":
-				parse += " 46";//parse.add(46); //Regla V' --> λ
-				break;
-			default:
-				error("Token inesperado en V'. Se encontro el token " + tokenActual.getCodigo() + " en la linea " + lexico.getLinea());
-				break;
-		}
-	}
+        public String V_prime(String lexemaId, String tipoActual) {
+                switch(tokenActual.getCodigo()) {
+                        case "par1":
+                                parse += " 45";//parse.add(45); //Regla V' --> (L)
+                                equipara("par1");
+                                L();
+                                equipara("par2");
+                                String retorno = semantico.obtenerTipoRetorno(lexemaId);
+                                if (retorno == null) {
+                                        throw new RuntimeException("Error semántico: '" + lexemaId +
+                                                "' no es una función en la línea " + lexico.getLinea());
+                                }
+                                return retorno;
+                        case "mayor":
+                        case "suma":
+                        case "punCom":
+                        case "coma":
+                        case "par2":
+                        case "asigOL":
+                                parse += " 46";//parse.add(46); //Regla V' --> λ
+                                return tipoActual;
+                        default:
+                                error("Token inesperado en V'. Se encontro el token " + tokenActual.getCodigo() + " en la linea " + lexico.getLinea());
+                                return "tipo_error";
+                }
+        }
 
 	//Funcion D
 	public void D() {


### PR DESCRIPTION
## Summary
- expose helpers in the lexer to query scope information
- prevent assignments to global variables when not inside a function
- ensure function calls evaluate to the return type for correct assignments

## Testing
- `javac -d bin @sources.txt`

------
https://chatgpt.com/codex/tasks/task_e_6850102a4e3083238fd2bc168e444c48