### PR TITLE
Add scope checks for local variables

### DIFF
--- a/src/ALexico/AnLexico.java
+++ b/src/ALexico/AnLexico.java
@@ -64,6 +64,11 @@ public class AnLexico {
                 return funcionActual != null;
         }
 
+        // Devuelve el nombre de la función actual o null si estamos en el ámbito global
+        public String getFuncionActual() {
+                return funcionActual;
+        }
+
         // Verifica si un identificador pertenece a la tabla global
         public boolean esVariableGlobal(String lexema) {
                 return tablaGlobal.containsKey(lexema);
@@ -239,23 +244,27 @@ public class AnLexico {
 		throw new RuntimeException("Carácter no reconocido: " + caracterActual + " en la línea " + linea + ".");
 	}
 
-	private void registrarSimboloGlobal(String lexema) {
+        private void registrarSimboloGlobal(String lexema) {
                 Map<String, Object> attrsUnion = new LinkedHashMap<>();
                 attrsUnion.put("despl", contadorIds++);
+                attrsUnion.put("ambito", "global");
                 tablaSimbolos.put(lexema, attrsUnion);
 
                 Map<String, Object> attrs = new LinkedHashMap<>();
                 attrs.put("despl", contadorGlobal++);
+                attrs.put("ambito", "global");
                 tablaGlobal.put(lexema, attrs);
         }
 
         private void registrarSimboloLocal(String lexema) {
                 Map<String, Object> attrsUnion = new LinkedHashMap<>();
                 attrsUnion.put("despl", contadorIds++);
+                attrsUnion.put("ambito", funcionActual);
                 tablaSimbolos.put(lexema, attrsUnion);
 
                 Map<String, Object> attrs = new LinkedHashMap<>();
                 attrs.put("despl", contadorLocal++);
+                attrs.put("ambito", funcionActual);
                 if (tablaLocalActual != null) {
                         tablaLocalActual.put(lexema, attrs);
                 }

--- a/src/AnSintDesRec/AnSemantico.java
+++ b/src/AnSintDesRec/AnSemantico.java
@@ -47,6 +47,17 @@ public class AnSemantico {
         }
 
         Map<String, Object> atributos = tablaSimbolos.get(lexema);
+
+        // Comprobar que el identificador está accesible en el ámbito actual
+        String ambito = (String) atributos.get("ambito");
+        if (ambito != null && !"global".equals(ambito)) {
+            // Es una variable local, debe coincidir la función actual
+            if (!lexico.dentroDeFuncion() || !ambito.equals(lexico.getFuncionActual())) {
+                throw new RuntimeException(
+                        "Error semántico: Variable '" + lexema + "' fuera de su ámbito en la línea " + lexico.getLinea());
+            }
+        }
+
         String tipo = (String) atributos.get("tipo");
 
         if (tipo == null) {
@@ -123,6 +134,18 @@ public class AnSemantico {
             throw new RuntimeException(
                     "Error semántico: No se puede asignar a la variable global '" + lexema +
                     "' fuera de una función en la línea " + lexico.getLinea());
+        }
+
+        // Verificar que la variable esté accesible en el ámbito actual
+        if (tablaSimbolos.containsKey(lexema)) {
+            Map<String, Object> atributos = tablaSimbolos.get(lexema);
+            String ambito = (String) atributos.get("ambito");
+            if (ambito != null && !"global".equals(ambito)) {
+                if (!lexico.dentroDeFuncion() || !ambito.equals(lexico.getFuncionActual())) {
+                    throw new RuntimeException(
+                            "Error semántico: Variable '" + lexema + "' fuera de su ámbito en la línea " + lexico.getLinea());
+                }
+            }
         }
 
         String tipoVariable = buscaTipoTS(lexema);


### PR DESCRIPTION
## Summary
- add method to get current function name in lexer
- track `ambito` attribute when registering symbols
- enforce scope checking in `buscaTipoTS`
- verify scope in `validarAsignacion`

## Testing
- `javac @sources.txt`

------
https://chatgpt.com/codex/tasks/task_e_6850464688b083238286c5ccbcbea689